### PR TITLE
Add the kubelet_identity property to module outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,7 @@ output "kube_admin_config_raw" {
   description = "The raw kube admin config, used with kubectl and other tools."
   value       = azurerm_kubernetes_cluster.cluster.kube_admin_config_raw
 }
+output "kubelet_identity" {
+  description = "The raw kubelet identity. Used for Azure role assignments."
+  value       = azurerm_kubernetes_cluster.cluster.kubelet_identity
+}


### PR DESCRIPTION
This property is useful for scenarios where you want to assign roles to the kubelet identity. A practical example is to assign the `AcrPull` role.