### PR TITLE
Add OMS and Key Vault CSI provider

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -36,6 +36,12 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     http_application_routing {
       enabled = var.http_application_routing
     }
+
+    azure_keyvault_secrets_provider {
+      enabled                  = var.azure_keyvault_secrets_provider.enabled
+      secret_rotation_enabled  = var.azure_keyvault_secrets_provider.secret_rotation_enabled
+      secret_rotation_interval = var.azure_keyvault_secrets_provider.secret_rotation_interval
+    }
   }
 
   network_profile {

--- a/aks.tf
+++ b/aks.tf
@@ -42,6 +42,9 @@ resource "azurerm_kubernetes_cluster" "cluster" {
       secret_rotation_enabled  = var.azure_keyvault_secrets_provider.secret_rotation_enabled
       secret_rotation_interval = var.azure_keyvault_secrets_provider.secret_rotation_interval
     }
+    open_service_mesh {
+      enabled = var.open_service_mesh
+    }
   }
 
   network_profile {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,11 @@ variable "azure_keyvault_secrets_provider" {
     secret_rotation_interval = null
   }
 }
+variable "open_service_mesh" {
+  description = "Enables the Open Service Mesh addon"
+  type        = bool
+  default     = false
+}
 variable "ingress_application_gateway_id" {
   description = "For adding AGIC to the cluster. Adding this block enables the Ingress controller, make sure you don't only have node pools with 'only_critical_addons_enabled' as AGIC will fail to deploy. For now, we only support defining existing Application Gateways."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,19 @@ variable "addons" {
     azure_policy   = true
   }
 }
+variable "azure_keyvault_secrets_provider" {
+  description = "Enable the Key Vault CSI driver."
+  type = object({
+    enabled                  = bool
+    secret_rotation_enabled  = bool
+    secret_rotation_interval = number
+  })
+  default = {
+    enabled                  = false
+    secret_rotation_enabled  = false
+    secret_rotation_interval = null
+  }
+}
 variable "ingress_application_gateway_id" {
   description = "For adding AGIC to the cluster. Adding this block enables the Ingress controller, make sure you don't only have node pools with 'only_critical_addons_enabled' as AGIC will fail to deploy. For now, we only support defining existing Application Gateways."
   type        = string


### PR DESCRIPTION
Adds the following variables
```hcl
variable "azure_keyvault_secrets_provider" {
  description = "Enable the Key Vault CSI driver."
  type = object({
    enabled                  = bool
    secret_rotation_enabled  = bool
    secret_rotation_interval = number
  })
  default = {
    enabled                  = false
    secret_rotation_enabled  = false
    secret_rotation_interval = null
  }
}
variable "open_service_mesh" {
  description = "Enables the Open Service Mesh addon"
  type        = bool
  default     = false
}
```
Closes #51 