### PR TITLE
fix(deployment-location): location is now a variable

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -1,8 +1,8 @@
 resource "azurerm_kubernetes_cluster" "cluster" {
   # General configurations:
   name                            = var.name
-  location                        = data.azurerm_resource_group.aks.location
   resource_group_name             = var.resource_group
+  location                        = var.location
   node_resource_group             = var.node_resource_group
   sku_tier                        = var.sku_tier
   dns_prefix                      = var.dns_prefix != null ? var.dns_prefix : local.default_dns_prefix

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,3 @@
-data "azurerm_resource_group" "aks" {
-  name = var.resource_group
-}
-
 data "azurerm_kubernetes_service_versions" "current" {
   location        = data.azurerm_resource_group.aks.location
   version_prefix  = var.kubernetes_version_prefix

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,17 @@ variable "name" {
   type        = string
   description = "Name the deployment."
 }
+
 variable "resource_group" {
   type        = string
   description = "The resource group you want your deployment in."
 }
+
+variable "location" {
+  type        = string
+  description = "The location you want your resources deployed to."
+}
+
 variable "node_resource_group" {
   type        = string
   description = "(Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created."


### PR DESCRIPTION
It no longer uses a data source.

Using a data source made the deployment want to redeploy the entire cluster if the underlying resource group had any minor changes to it, making it hard to have a stable deployment with the module. Removing the data source and asking for a location input shouldn't make it harder to use, but removes any weird dependency issues.

Closes #60

Signed-off-by: Roberth Strand <roberth.strand@crayon.com>